### PR TITLE
Removing adb requirement

### DIFF
--- a/media_player/firetv.py
+++ b/media_player/firetv.py
@@ -17,8 +17,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['libusb1==1.6.6', 'rsa==3.4.2',
-                'https://github.com/JeffLIrion/python-firetv/zipball/master#firetv==1.0.5.dev',
-                'https://github.com/JeffLIrion/python-adb/zipball/master#adb==1.3.0.dev']
+                'https://github.com/JeffLIrion/python-firetv/zipball/master#firetv==1.0.5.dev']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
The strict adb requirement is problematic here, you rather want to reference it inside python-firetv's setup.py - currently it tries to install the upstream version of adb there - not your fork.