### PR TITLE
Update Readme to clarify ADB Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ media_player:
 
 If you get a "Device authentication required, no keys available" error when trying to setup Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your Fire TV from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).  
 
-**Important!**  In the dialog appearing on your Fire TV device, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
+**Important!**  In the dialog appearing on your Fire TV, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
 
 Once you've successfully connected to your Fire TV via the command `adb connect <ipaddress>`, the files `adbkey` and `adbkey.pub` will be created on your computer.  Copy these to your Home Assistant folder and add the path to the `adbkey` file to your configuration.  
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ media_player:
 
 If you get a "Device authentication required, no keys available" error when trying to setup Fire TV, then you'll need to create an adbkey and add its path to your configuration.  Follow the instructions on this page to connect to your Fire TV from your computer: [Connecting to Fire TV Through adb](https://developer.amazon.com/zh/docs/fire-tv/connecting-adb-to-device.html).  
 
-**Important!**  You must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
+**Important!**  In the dialog appearing on your Fire TV device, you must check the box that says "always allow connections from this device."  ADB authentication in Home Assistant will only work using a trusted key.
 
 Once you've successfully connected to your Fire TV via the command `adb connect <ipaddress>`, the files `adbkey` and `adbkey.pub` will be created on your computer.  Copy these to your Home Assistant folder and add the path to the `adbkey` file to your configuration.  
 


### PR DESCRIPTION
it took me a while to understand, that the option „always allow connections from this device“ appears on the Fire TV device itself, so i added a sentence to the otherwise thorow instructions..