### PR TITLE
Test adbkey paths

### DIFF
--- a/media_player/firetv.py
+++ b/media_player/firetv.py
@@ -51,6 +51,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = '{0}:{1}'.format(config.get(CONF_HOST), config.get(CONF_PORT))
     name = config.get(CONF_NAME)
     adbkey = config.get(CONF_ADBKEY)
+    
+    if adbkey != "":
+        if not os.path.exists(adbkey):
+            raise FileNotFoundError("No ADB private key exists at the specified adbkey path")
+        if not os.path.exists(adbkey + ".pub"):
+            raise FileNotFoundError("No ADB public key exists at the specified adbkey path. The public key must have the same name as the prviate key, appended with .pub")
 
     device = FireTVDevice(host, name, adbkey)
     adb_log = " using adbkey='{0}'".format(adbkey) if adbkey else ""


### PR DESCRIPTION
Specifically test for private and public key paths, and throw FileNotFoundError in the case where they aren't found.

Addresses #12, where it was identified that no specific error or message is logged when the private key exists, but the public key doesn't.